### PR TITLE
Add getAll method

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,12 +67,13 @@ Screendoor.prototype.url = function( options ) {
  * @param mixed { string|int } site_id
  */
 
-Screendoor.prototype.getSiteProjects = function( site_id, callback ) {
+Screendoor.prototype.getSiteProjects = function( site_id, params, callback ) {
 
 	var self 	= this,
 		url 	= self.url( {
 
-		path : '/sites/' + site_id + '/projects'
+		path : '/sites/' + site_id + '/projects',
+		params: params || {}
 
 	} );
 
@@ -122,12 +123,13 @@ Screendoor.prototype.getProject = function ( site_id, project_id, callback ) {
  * @param mixed { string|int } project_id
  */
 
-Screendoor.prototype.getProjectFields = function( project_id, callback ) {
+Screendoor.prototype.getProjectFields = function( project_id, params, callback ) {
 
 	var self 	= this,
 		url 	= self.url({
 
-		path : '/projects/' + project_id + '/response_fields'
+		path : '/projects/' + project_id + '/response_fields',
+		params: params || {}
 
 	} );
 

--- a/index.js
+++ b/index.js
@@ -76,13 +76,13 @@ Screendoor.prototype.getSiteProjects = function( site_id, callback ) {
 
 	} );
 
-	self.request( 'GET', url, null, function( err, result ) {
+	self.request( 'GET', url, null, function( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -104,13 +104,13 @@ Screendoor.prototype.getProject = function ( site_id, project_id, callback ) {
 
 	} );
 
-	self.request( 'GET', url, null, function ( err, result ) {
+	self.request( 'GET', url, null, function ( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -131,13 +131,13 @@ Screendoor.prototype.getProjectFields = function( project_id, callback ) {
 
 	} );
 
-	self.request( 'GET', url, null, function ( err, result ) {
+	self.request( 'GET', url, null, function ( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -164,13 +164,13 @@ Screendoor.prototype.getProjectResponses = function ( project_id, params, callba
 
 		} );
 
-	self.request( 'GET', url, null, function ( err, result ) {
+	self.request( 'GET', url, null, function ( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -197,15 +197,15 @@ Screendoor.prototype.getProjectResponse = function ( project_id, response_id, re
 	});
 
 
-	self.request( 'GET', url, null, function ( err, result ) {
+	self.request( 'GET', url, null, function ( err, result, httpResponse ) {
 
 		if ( err ) {
 
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -249,13 +249,13 @@ Screendoor.prototype.setProjectResponse = function( project_id, response_fields,
 		}
 	}
 
-	self.request( 'POST', url, data, function ( err, result ) {
+	self.request( 'POST', url, data, function ( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -296,13 +296,13 @@ Screendoor.prototype.setProjectResponse = function( project_id, response_fields,
 		}
 	}
 
- 	self.request( 'PUT', url, data, function ( err, result ) {
+ 	self.request( 'PUT', url, data, function ( err, result, httpResponse ) {
 
 		if ( err ) {
-			return callback( err, null );
+			return callback( err, null, httpResponse );
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -342,7 +342,7 @@ Screendoor.prototype.uploadFile = function( field_id, encoded_file, file_options
 
     };
 
-    self.request( 'POST', url, data, function( err, result ){
+    self.request( 'POST', url, data, function( err, result, httpResponse ) {
 
 		if ( err ) {
 
@@ -356,7 +356,7 @@ Screendoor.prototype.uploadFile = function( field_id, encoded_file, file_options
 
 		}
 
-		return callback( null, result );
+		return callback( null, result, httpResponse );
 
 	} );
 
@@ -406,7 +406,7 @@ Screendoor.prototype.request = function( method, url, data, callback ){
 
     	if ( 'statusCode' in httpResponse && 200 !== httpResponse.statusCode ){
 
-    		return callback( new Error( 'Unusable status in response.' ), null );
+    		return callback( new Error( 'Unusable status in response.' ), null, httpResponse );
 
     	}
 
@@ -414,11 +414,11 @@ Screendoor.prototype.request = function( method, url, data, callback ){
 
     	if ( 'errors' in result ){
 
-    		return callback( new Error( result.errors ), null );
+    		return callback( new Error( result.errors ), null, httpResponse );
 
     	}
 
-    	return callback( null, result );
+    	return callback( null, result, httpResponse );
 
 	} );
 

--- a/index.js
+++ b/index.js
@@ -177,6 +177,48 @@ Screendoor.prototype.getProjectResponses = function ( project_id, params, callba
 };
 
 /**
+ * Get All Data
+ *
+ * @param function fn
+ * @param mixed { string|int } id
+ * @param mixed { null|object } params
+ *		sort: string
+ *		direction: string
+ * 		page: int
+ * 		per_page: int
+ */
+Screendoor.prototype.getAll = function ( fn, id, params, callback ) {
+	var self = this;
+	var allData = [];
+	var linkHeader = null;
+
+	var getAllData = function ( page ) {
+		params.page = page ? page : 1;
+
+		fn.call( self, id, params, function (err, results, httpResponse ) {
+			
+			linkHeader = parse( httpResponse.headers.link );
+
+			if ( err ) {
+				return callback( err, null, httpResponse );
+			}
+
+			results.forEach( function ( result ) {	
+				allData.push( result );
+			} );
+
+			if ( linkHeader && linkHeader.next ) {
+				return getAllData( linkHeader.next.page );
+			}
+
+			callback( null, allData );
+		});
+	};
+
+	getAllData();
+};
+
+/**
  * Get Single Response
  *
  * @param mixed { string|int } project_id

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
  */
 
 var request = require( 'request' );
+var parse = require( 'parse-link-header' );
 
 /**
  * Declare Screendoor Class

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/thoughtis/screendoor-api-node",
   "dependencies": {
+    "parse-link-header": "^0.4.1",
     "request": "^2.65.0"
   }
 }


### PR DESCRIPTION
This adds a getAll method to the Screendoor prototype. It can be used in conjunction with any other Screendoor 'get' methods to automatically handle pagination and return all data. For example:

```js
screendoor.getAll(screendoor.getProjectResponses, 2189, { per_page: 5 }, function (err, result) {
    // result contains all project responses
});
```

`per_page` is not necessary, it is used in the params object to help test pagination 